### PR TITLE
empty bug report option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-empty.yml
+++ b/.github/ISSUE_TEMPLATE/bug-empty.yml
@@ -1,0 +1,23 @@
+name: 🐛 Bug (Empty)
+description: File a bug report without a pre-built template
+title: "🐛 Bug: "
+type: "bug"
+labels: ["bug"]
+projects: ["CumulusDS/20"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Bug Report
+  - type: textarea
+    attributes:
+      label: Bug Report
+      description: Report your bug here.
+      placeholder: |
+        describe your bug
+        Don't forget to include details like:
+        1. expected behavior
+        2. Observed behaviour
+        3. steps to reproduce
+    validations:
+      required: true


### PR DESCRIPTION
I would like to be able to file a bug report without the precanned prompts in the current bug report.

I get the need for them for external people like when Derek and Zach file bugs, but SQA reported bugs are different types of bugs. Sometimes I am reporting a bug during a test and I do not need all those fields. Typically what I do is fill out only the top one, submit the issue, then go back and edit it to remove the titles and everything from the empty fields. 

It is a chore. What I like about the bug template is the consistency in title naming, having the bug icon to begin the name, and the auto labelling and auto tagging of the bug. 

What I need is essentially a blank issue template that will do those three things for me. 

I copied the bug template and only left the first textarea in there because I didnt know if having an empty body would work. I think this will get me what I want. If you look through the bugs, my bugs, rishi's bigs, and marcs bugs are all from blank templates. only external people use the template

Thank you for your attention to this matter!